### PR TITLE
Avoid git pull error & add alt du args for macosx

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,10 @@
 VERSION=v1.1.3
 
 default: zepto
-	@cd $< && git pull && git checkout $(VERSION) && npm install && npm run-script dist
+	@cd $< && git checkout master && git pull && git checkout $(VERSION) && npm install && npm run-script dist
 	@cp -f $</dist/zepto.js .
 	@cp -f $</dist/zepto.min.js .
+	@du -bh zepto.* 2>/dev/null || du -h zepto.*
 
 zepto:
 	@git clone https://github.com/madrobby/zepto.git $@


### PR DESCRIPTION
Makefile couldn't be executed more than once due
to git pull error: `git checkout master` is added
before `git pull` to solve this issue.
